### PR TITLE
FOLIO-3045: Replace http by https in http://maven.indexdata.com/

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -59,11 +59,11 @@ eclipse {
 }
 
 repositories {
-  maven { url 'http://maven.k-int.com/content/repositories/public' }
+  maven { url 'https://maven.k-int.com/content/repositories/public' }
   jcenter()
   mavenLocal()
   maven { url 'https://repo.grails.org/grails/core' }
-  maven { url 'http://maven.indexdata.com/' }
+  maven { url 'https://maven.indexdata.com/' }
 }
 
 sourceSets {


### PR DESCRIPTION
The same for http://maven.k-int.com/content/repositories/public

A machine-in-the-middle attack can change the download
to contain malware. Using https will prevent this.

Details: https://issues.folio.org/browse/FOLIO-3044